### PR TITLE
Fix conda badge and links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # eval_type_backport
 
-[![Build Status](https://github.com/alexmojaki/eval_type_backport/workflows/Tests/badge.svg)](https://github.com/alexmojaki/eval_type_backport/actions) [![Coverage Status](https://coveralls.io/repos/github/alexmojaki/eval_type_backport/badge.svg)](https://coveralls.io/github/alexmojaki/eval_type_backport) [![Supports Python versions 3.7+, including PyPy](https://img.shields.io/pypi/pyversions/eval_type_backport.svg)](https://pypi.python.org/pypi/eval_type_backport) [![Anaconda's conda-forge-channel](https://anaconda.org/conda-forge/eval_type_backport/badges/version.svg)](https://anaconda.org/conda-forge/eval_type_backport)
+[![Build Status](https://github.com/alexmojaki/eval_type_backport/workflows/Tests/badge.svg)](https://github.com/alexmojaki/eval_type_backport/actions) [![Coverage Status](https://coveralls.io/repos/github/alexmojaki/eval_type_backport/badge.svg)](https://coveralls.io/github/alexmojaki/eval_type_backport) [![Supports Python versions 3.7+, including PyPy](https://img.shields.io/pypi/pyversions/eval_type_backport.svg)](https://pypi.python.org/pypi/eval_type_backport) [![Anaconda's conda-forge channel](https://anaconda.org/conda-forge/eval-type-backport/badges/version.svg)](https://anaconda.org/conda-forge/eval-type-backport)
 
 This is a tiny package providing a replacement for `typing._eval_type` to support newer typing features in older Python versions.
 


### PR DESCRIPTION
Forgot to update the links to the hyphenated `conda-forge` package.