### PR TITLE
Export `typing.ForwardRef` subclass

### DIFF
--- a/eval_type_backport/__init__.py
+++ b/eval_type_backport/__init__.py
@@ -1,4 +1,4 @@
-from .eval_type_backport import eval_type_backport
+from .eval_type_backport import ForwardRef, eval_type_backport
 
 try:
     from .version import __version__
@@ -6,4 +6,4 @@ except ImportError:  # pragma: no cover
     # version.py is auto-generated with the git tag when building
     __version__ = '???'
 
-__all__ = ['eval_type_backport', '__version__']
+__all__ = ['ForwardRef', 'eval_type_backport', '__version__']

--- a/tests/test_eval_type_backport.py
+++ b/tests/test_eval_type_backport.py
@@ -122,6 +122,8 @@ def test_other_type_error():
     ]:
         with pytest.raises(TypeError):
             check_eval(code, None)
+        with pytest.raises(TypeError):
+            eval_type(ForwardRef(code), None, None)
 
 
 class FooMeta(type):


### PR DESCRIPTION
Closes #17.