### PR TITLE
Backport PEP 585 generic alias forward refs

### DIFF
--- a/eval_type_backport/eval_type_backport.py
+++ b/eval_type_backport/eval_type_backport.py
@@ -11,7 +11,10 @@ import typing
 import types
 import uuid
 from collections.abc import Mapping
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:  # pragma: no cover
+    from _typeshed import Unused
 
 
 def is_unsupported_types_for_union_error(e: TypeError) -> bool:
@@ -225,7 +228,7 @@ def _eval_forward_ref(
     localns: Mapping[str, Any] | None,
     recursive_guard: frozenset[str],
     try_default: bool,
-) -> Any:  # pragma: no cover
+) -> Any:
     forward_arg = value.__forward_arg__
     if forward_arg in recursive_guard:
         return value
@@ -257,7 +260,7 @@ def _eval_type_backport(
     localns: Mapping[str, Any] | None,
     recursive_guard: frozenset[str] = frozenset(),
     try_default: bool = True,
-) -> Any:  # pragma: no cover
+) -> Any:
     if isinstance(value, typing.ForwardRef):
         return _eval_forward_ref(
             value, globalns, localns, recursive_guard, try_default=try_default
@@ -288,23 +291,33 @@ def _eval_type_backport(
     return value
 
 
-def eval_type_backport(
-    value: Any,
-    globalns: dict[str, Any] | None = None,
-    localns: Mapping[str, Any] | None = None,
-    try_default: bool = True,
-    *args: Any,
-    **kwargs: Any,
-) -> Any:
-    """
-    Like `typing._eval_type`, but lets older Python versions use newer typing features.
-    Specifically, this transforms `X | Y` into `typing.Union[X, Y]`
-    and `list[X]` into `typing.List[X]` etc. (for all the types made generic in PEP 585)
-    if the original syntax is not supported in the current Python version.
-    """
-    if sys.version_info[:2] >= (3, 11):
+if sys.version_info[:2] >= (3, 11):
+
+    def eval_type_backport(  # type: ignore  # allow duplicate declaration
+        value: Any,
+        globalns: dict[str, Any] | None = None,
+        localns: Mapping[str, Any] | None = None,
+        try_default: Unused = True,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Any:
+        """Alias to typing._eval_type (Python 3.11+)."""
         return typing._eval_type(value, globalns, localns, *args, **kwargs)  # type: ignore
 
-    return _eval_type_backport(
-        value, globalns, localns, try_default=try_default
-    )  # pragma: no cover
+else:
+
+    def eval_type_backport(
+        value: Any,
+        globalns: dict[str, Any] | None = None,
+        localns: Mapping[str, Any] | None = None,
+        try_default: bool = True,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Any:
+        """
+        Like `typing._eval_type`, but lets older Python versions use newer typing features.
+        Specifically, this transforms `X | Y` into `typing.Union[X, Y]`
+        and `list[X]` into `typing.List[X]` etc. (for all the types made generic in PEP 585)
+        if the original syntax is not supported in the current Python version.
+        """
+        return _eval_type_backport(value, globalns, localns, try_default=try_default)

--- a/eval_type_backport/eval_type_backport.py
+++ b/eval_type_backport/eval_type_backport.py
@@ -225,7 +225,7 @@ def _eval_forward_ref(
     localns: Mapping[str, Any] | None,
     recursive_guard: frozenset[str],
     try_default: bool,
-) -> Any:
+) -> Any:  # pragma: no cover
     forward_arg = value.__forward_arg__
     if forward_arg in recursive_guard:
         return value
@@ -257,7 +257,7 @@ def _eval_type_backport(
     localns: Mapping[str, Any] | None,
     recursive_guard: frozenset[str] = frozenset(),
     try_default: bool = True,
-) -> Any:
+) -> Any:  # pragma: no cover
     if isinstance(value, typing.ForwardRef):
         return _eval_forward_ref(
             value, globalns, localns, recursive_guard, try_default=try_default
@@ -305,4 +305,6 @@ def eval_type_backport(
     if sys.version_info[:2] >= (3, 11):
         return typing._eval_type(value, globalns, localns, *args, **kwargs)  # type: ignore
 
-    return _eval_type_backport(value, globalns, localns, try_default=try_default)
+    return _eval_type_backport(
+        value, globalns, localns, try_default=try_default
+    )  # pragma: no cover

--- a/eval_type_backport/eval_type_backport.py
+++ b/eval_type_backport/eval_type_backport.py
@@ -115,9 +115,7 @@ class BackportTransformer(ast.NodeTransformer):
                 if hasattr(original_ref, attr):
                     setattr(ref, attr, getattr(original_ref, attr))
         ref.__forward_code__ = compile(node, '<node>', 'eval')
-        return typing._eval_type(  # type: ignore
-            ref, self.globalns, self.localns
-        )
+        return original_eval_type(ref, self.globalns, self.localns)
 
     def visit_BinOp(self, node) -> ast.BinOp | ast.Subscript:
         node = self.generic_visit(node)
@@ -174,6 +172,7 @@ class BackportTransformer(ast.NodeTransformer):
 
 
 original_evaluate = typing.ForwardRef._evaluate
+original_eval_type = typing._eval_type  # type: ignore[attr-defined]
 GenericAlias = getattr(types, 'GenericAlias', None)
 UnionType = getattr(types, 'UnionType', None)
 _GenericAlias = getattr(typing, '_GenericAlias', None)
@@ -237,9 +236,7 @@ def _eval_forward_ref(
         evaluated = _eval_direct(value, globalns, localns)
     else:
         try:
-            evaluated = typing._eval_type(  # type: ignore
-                value, globalns, localns
-            )
+            evaluated = original_eval_type(value, globalns, localns)
         except TypeError as e:
             if not is_backport_fixable_error(e):
                 raise
@@ -302,7 +299,7 @@ if sys.version_info[:2] >= (3, 11):
         **kwargs: Any,
     ) -> Any:
         """Alias to typing._eval_type (Python 3.11+)."""
-        return typing._eval_type(value, globalns, localns, *args, **kwargs)  # type: ignore
+        return original_eval_type(value, globalns, localns, *args, **kwargs)
 
 else:
 
@@ -324,9 +321,10 @@ else:
 
 
 def install_patch() -> None:
-    """Monkey-patch `typing.ForwardRef._evaluate` to support newer syntax on older Python versions.
+    """Monkey-patch `typing` internals to support newer syntax on older Python versions.
 
-    This indirectly makes functions like `typing.get_type_hints` and `typing._eval_type` work as well.
+    This makes functions like `typing.get_type_hints` and `typing._eval_type` work as well.
     """
-    if sys.version_info[:2] < (3, 10):
+    if sys.version_info[:2] < (3, 11):
         typing.ForwardRef._evaluate = ForwardRef._evaluate  # type: ignore
+        typing._eval_type = eval_type_backport  # type: ignore

--- a/eval_type_backport/eval_type_backport.py
+++ b/eval_type_backport/eval_type_backport.py
@@ -4,15 +4,14 @@ import ast
 import collections.abc
 import contextlib
 import functools
+import operator
 import re
 import sys
 import typing
+import types
 import uuid
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any
-
-if TYPE_CHECKING:  # pragma: no cover
-    from _typeshed import Unused
+from typing import Any
 
 
 def is_unsupported_types_for_union_error(e: TypeError) -> bool:
@@ -172,6 +171,12 @@ class BackportTransformer(ast.NodeTransformer):
 
 
 original_evaluate = typing.ForwardRef._evaluate
+GenericAlias = getattr(types, 'GenericAlias', None)
+UnionType = getattr(types, 'UnionType', None)
+_GenericAlias = getattr(typing, '_GenericAlias', None)
+_eval_type_generic_aliases = tuple(
+    alias for alias in (GenericAlias, _GenericAlias, UnionType) if alias is not None
+)
 
 
 if sys.version_info[:2] >= (3, 10):
@@ -214,41 +219,90 @@ def _eval_direct(
     return transformer.eval_type(tree, original_ref=value)
 
 
-if sys.version_info[:2] >= (3, 10):
-    def eval_type_backport(
-        value: Any,
-        globalns: dict[str, Any] | None = None,
-        localns: Mapping[str, Any] | None = None,
-        try_default: Unused = True,
-        *args: Any,
-        **kwargs: Any,
-    ) -> Any:
-        """Alias to typing._eval_type (Python 3.10+)."""
-        return typing._eval_type(value, globalns, localns, *args, **kwargs)  # type: ignore
+def _eval_forward_ref(
+    value: typing.ForwardRef,
+    globalns: dict[str, Any] | None,
+    localns: Mapping[str, Any] | None,
+    recursive_guard: frozenset[str],
+    try_default: bool,
+) -> Any:
+    forward_arg = value.__forward_arg__
+    if forward_arg in recursive_guard:
+        return value
 
-else:
-
-    def eval_type_backport(
-        value: Any,
-        globalns: dict[str, Any] | None = None,
-        localns: Mapping[str, Any] | None = None,
-        try_default: bool = True,
-    ) -> Any:
-        """
-        Like `typing._eval_type`, but lets older Python versions use newer typing features.
-        Specifically, this transforms `X | Y` into `typing.Union[X, Y]`
-        and `list[X]` into `typing.List[X]` etc. (for all the types made generic in PEP 585)
-        if the original syntax is not supported in the current Python version.
-        """
-        if not try_default:
-            return _eval_direct(value, globalns, localns)
+    if not try_default:
+        evaluated = _eval_direct(value, globalns, localns)
+    else:
         try:
-            return typing._eval_type(  # type: ignore
+            evaluated = typing._eval_type(  # type: ignore
                 value, globalns, localns
             )
         except TypeError as e:
-            if not (
-                isinstance(value, typing.ForwardRef) and is_backport_fixable_error(e)
-            ):
+            if not is_backport_fixable_error(e):
                 raise
-            return _eval_direct(value, globalns, localns)
+            evaluated = _eval_direct(value, globalns, localns)
+
+    return _eval_type_backport(
+        evaluated,
+        globalns,
+        localns,
+        recursive_guard | {forward_arg},
+        try_default=True,
+    )
+
+
+def _eval_type_backport(
+    value: Any,
+    globalns: dict[str, Any] | None,
+    localns: Mapping[str, Any] | None,
+    recursive_guard: frozenset[str] = frozenset(),
+    try_default: bool = True,
+) -> Any:
+    if isinstance(value, typing.ForwardRef):
+        return _eval_forward_ref(
+            value, globalns, localns, recursive_guard, try_default=try_default
+        )
+
+    if GenericAlias is not None and isinstance(value, GenericAlias):
+        value = GenericAlias(
+            value.__origin__,
+            tuple(
+                typing.ForwardRef(arg) if isinstance(arg, str) else arg
+                for arg in value.__args__
+            ),
+        )
+
+    if _eval_type_generic_aliases and isinstance(value, _eval_type_generic_aliases):
+        evaluated_args = tuple(
+            _eval_type_backport(arg, globalns, localns, recursive_guard)
+            for arg in value.__args__
+        )
+        if evaluated_args == value.__args__:
+            return value
+        if GenericAlias is not None and isinstance(value, GenericAlias):
+            return GenericAlias(value.__origin__, evaluated_args)
+        if UnionType is not None and isinstance(value, UnionType):
+            return functools.reduce(operator.or_, evaluated_args)
+        return value.copy_with(evaluated_args)
+
+    return value
+
+
+def eval_type_backport(
+    value: Any,
+    globalns: dict[str, Any] | None = None,
+    localns: Mapping[str, Any] | None = None,
+    try_default: bool = True,
+    *args: Any,
+    **kwargs: Any,
+) -> Any:
+    """
+    Like `typing._eval_type`, but lets older Python versions use newer typing features.
+    Specifically, this transforms `X | Y` into `typing.Union[X, Y]`
+    and `list[X]` into `typing.List[X]` etc. (for all the types made generic in PEP 585)
+    if the original syntax is not supported in the current Python version.
+    """
+    if sys.version_info[:2] >= (3, 11):
+        return typing._eval_type(value, globalns, localns, *args, **kwargs)  # type: ignore
+
+    return _eval_type_backport(value, globalns, localns, try_default=try_default)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,8 +12,8 @@ venv = "venv"
 
 [tool.ruff]
 line-length = 89
-flake8-quotes = {inline-quotes = 'single', multiline-quotes = 'double'}
-mccabe = { max-complexity = 14 }
+lint.flake8-quotes = {inline-quotes = 'single', multiline-quotes = 'double'}
+lint.mccabe = { max-complexity = 14 }
 target-version = "py38"
 
 [tool.ruff.format]

--- a/tests/test_eval_type_backport.py
+++ b/tests/test_eval_type_backport.py
@@ -461,15 +461,6 @@ def test_install_patch_supports_get_type_hints():
     try:
         install_patch()
         assert t.get_type_hints(Foo) == {'value': t.Union[int, str]}
-        if sys.version_info[:2] >= (3, 9):
-
-            class Node:
-                pass
-
-            Node.__annotations__ = {'children': list['Node']}
-            assert t.get_type_hints(Node, globals(), locals()) == {
-                'children': list[Node]
-            }
 
         if sys.version_info[:2] < (3, 11):
             assert t.ForwardRef._evaluate is ForwardRef._evaluate

--- a/tests/test_eval_type_backport.py
+++ b/tests/test_eval_type_backport.py
@@ -5,7 +5,6 @@ import contextlib
 import importlib
 import re
 import sys
-import textwrap
 import typing as t
 
 import pytest
@@ -433,22 +432,12 @@ def test_stringified_pep585_forward_refs():
     class C2:
         pass
 
-    scope = {'List': t.List, 'C2': C2}
-    exec(
-        textwrap.dedent(
-            """
-            from __future__ import annotations
+    class C3:
+        a: t.List[list['C2']]
 
-            class C3:
-                a: List[list["C2"]]
-            """
-        ),
-        scope,
+    result = eval_type_backport(
+        t.ForwardRef(C3.__annotations__['a']), globals(), locals()
     )
-    C3 = scope['C3']
-    assert C3.__annotations__['a'] == "List[list['C2']]"
-
-    result = eval_type_backport(t.ForwardRef(C3.__annotations__['a']), globals(), scope)
     expected = t.List[list[C2]] if sys.version_info[:2] >= (3, 9) else t.List[t.List[C2]]
     assert result == expected
 

--- a/tests/test_eval_type_backport.py
+++ b/tests/test_eval_type_backport.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import collections
 import contextlib
-import importlib
 import re
 import sys
 import typing as t
@@ -11,12 +10,13 @@ import pytest
 
 import eval_type_backport as eval_type_backport_module
 from eval_type_backport import ForwardRef, eval_type_backport, install_patch
-from eval_type_backport.eval_type_backport import new_generic_types
+from eval_type_backport.eval_type_backport import (
+    _eval_forward_ref,
+    _eval_type_backport,
+    new_generic_types,
+)
 
 str((collections, contextlib, re))  # mark these as used (by eval calls)
-eval_type_backport_impl = importlib.import_module(
-    'eval_type_backport.eval_type_backport'
-)
 
 
 eval_type = t._eval_type  # type: ignore[attr-defined]
@@ -402,26 +402,20 @@ def test_private_backport_evaluator_pep585_forward_refs():
     expected = list[C] if sys.version_info[:2] >= (3, 9) else t.List[C]
 
     if sys.version_info[:2] >= (3, 9):
-        assert (
-            eval_type_backport_impl._eval_type_backport(list['C'], globals(), locals())
-            == expected
-        )
+        assert _eval_type_backport(list['C'], globals(), locals()) == expected
     assert (
-        eval_type_backport_impl._eval_type_backport(
-            t.ForwardRef('list["C"]'), globals(), locals()
-        )
-        == expected
+        _eval_type_backport(t.ForwardRef('list["C"]'), globals(), locals()) == expected
     )
     if sys.version_info[:2] < (3, 14):
         assert (
-            eval_type_backport_impl._eval_type_backport(
+            _eval_type_backport(
                 t.ForwardRef('list["C"]'), globals(), locals(), try_default=False
             )
             == expected
         )
     recursive_ref = t.ForwardRef('X')
     assert (
-        eval_type_backport_impl._eval_forward_ref(
+        _eval_forward_ref(
             recursive_ref, globals(), locals(), frozenset({'X'}), try_default=True
         )
         is recursive_ref

--- a/tests/test_eval_type_backport.py
+++ b/tests/test_eval_type_backport.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import collections
 import contextlib
+import importlib
 import re
 import sys
 import textwrap
@@ -13,6 +14,9 @@ from eval_type_backport import ForwardRef, eval_type_backport
 from eval_type_backport.eval_type_backport import new_generic_types
 
 str((collections, contextlib, re))  # mark these as used (by eval calls)
+eval_type_backport_impl = importlib.import_module(
+    'eval_type_backport.eval_type_backport'
+)
 
 
 eval_type = t._eval_type  # type: ignore[attr-defined]
@@ -388,6 +392,39 @@ def test_pep585_generic_alias_forward_refs():
     assert (
         eval_type_backport(C2.__annotations__['a'], globals(), locals())
         == list[t.Union[C2, int]]
+    )
+
+
+def test_private_backport_evaluator_pep585_forward_refs():
+    class C:
+        pass
+
+    expected = list[C] if sys.version_info[:2] >= (3, 9) else t.List[C]
+
+    if sys.version_info[:2] >= (3, 9):
+        assert (
+            eval_type_backport_impl._eval_type_backport(list['C'], globals(), locals())
+            == expected
+        )
+    assert (
+        eval_type_backport_impl._eval_type_backport(
+            t.ForwardRef('list["C"]'), globals(), locals()
+        )
+        == expected
+    )
+    if sys.version_info[:2] < (3, 14):
+        assert (
+            eval_type_backport_impl._eval_type_backport(
+                t.ForwardRef('list["C"]'), globals(), locals(), try_default=False
+            )
+            == expected
+        )
+    recursive_ref = t.ForwardRef('X')
+    assert (
+        eval_type_backport_impl._eval_forward_ref(
+            recursive_ref, globals(), locals(), frozenset({'X'}), try_default=True
+        )
+        is recursive_ref
     )
 
 

--- a/tests/test_eval_type_backport.py
+++ b/tests/test_eval_type_backport.py
@@ -457,12 +457,26 @@ def test_install_patch_supports_get_type_hints():
         value: int | str
 
     original_evaluate = t.ForwardRef._evaluate
+    original_eval_type = t._eval_type  # type: ignore[attr-defined]
     try:
         install_patch()
         assert t.get_type_hints(Foo) == {'value': t.Union[int, str]}
-        if sys.version_info[:2] < (3, 10):
+        if sys.version_info[:2] >= (3, 9):
+
+            class Node:
+                pass
+
+            Node.__annotations__ = {'children': list['Node']}
+            assert t.get_type_hints(Node, globals(), locals()) == {
+                'children': list[Node]
+            }
+
+        if sys.version_info[:2] < (3, 11):
             assert t.ForwardRef._evaluate is ForwardRef._evaluate
+            assert t._eval_type is eval_type_backport  # type: ignore[attr-defined]
         else:
             assert t.ForwardRef._evaluate is original_evaluate
+            assert t._eval_type is original_eval_type  # type: ignore[attr-defined]
     finally:
         t.ForwardRef._evaluate = original_evaluate
+        t._eval_type = original_eval_type  # type: ignore[attr-defined]

--- a/tests/test_eval_type_backport.py
+++ b/tests/test_eval_type_backport.py
@@ -3,13 +3,10 @@ from __future__ import annotations
 import collections
 import contextlib
 import importlib
-import importlib.util
-import pathlib
 import re
 import sys
 import textwrap
 import typing as t
-import types
 
 import pytest
 
@@ -24,33 +21,6 @@ eval_type_backport_impl = importlib.import_module(
 
 
 eval_type = t._eval_type  # type: ignore[attr-defined]
-
-
-def load_impl_with_version(
-    monkeypatch: pytest.MonkeyPatch,
-    version_info: tuple[int, int],
-    *,
-    generic_alias: type | None = None,
-    union_type: type | None = None,
-) -> types.ModuleType:
-    if generic_alias is not None:
-        monkeypatch.setattr(types, 'GenericAlias', generic_alias, raising=False)
-    if union_type is not None:
-        monkeypatch.setattr(types, 'UnionType', union_type, raising=False)
-    monkeypatch.setattr(sys, 'version_info', version_info)
-
-    module_file = eval_type_backport_impl.__file__
-    assert module_file is not None
-    module_path = pathlib.Path(module_file)
-    spec = importlib.util.spec_from_file_location(
-        f'eval_type_backport_test_{version_info[0]}_{version_info[1]}',
-        module_path,
-    )
-    assert spec is not None
-    assert spec.loader is not None
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
 
 
 def eval_kwargs(code: str):
@@ -457,54 +427,6 @@ def test_private_backport_evaluator_pep585_forward_refs():
         )
         is recursive_ref
     )
-
-
-def test_private_backport_evaluator_version_coverage(monkeypatch: pytest.MonkeyPatch):
-    if sys.version_info[:2] >= (3, 11):
-        pytest.skip('old-version coverage shim')
-    original_version = sys.version_info[:2]
-
-    newer_impl = load_impl_with_version(monkeypatch, (3, 11))
-    assert newer_impl.eval_type_backport(int, globals(), locals()) is int
-
-    class FakeGenericAlias:
-        def __init__(self, origin: t.Any, args: t.Any):
-            self.__origin__ = origin
-            self.__args__ = args if isinstance(args, tuple) else (args,)
-
-        def __eq__(self, other: object) -> bool:
-            return (
-                isinstance(other, FakeGenericAlias)
-                and self.__origin__ == other.__origin__
-                and self.__args__ == other.__args__
-            )
-
-    class FakeUnionType:
-        def __init__(self, args: tuple[t.Any, ...]):
-            self.__args__ = args
-
-    class OrableMeta(type):
-        def __or__(self, other: object):
-            return ('union', self, other)
-
-    class A(metaclass=OrableMeta):
-        pass
-
-    class B(metaclass=OrableMeta):
-        pass
-
-    old_impl = load_impl_with_version(
-        monkeypatch,
-        original_version,
-        generic_alias=FakeGenericAlias,
-        union_type=FakeUnionType,
-    )
-    assert old_impl._eval_type_backport(
-        FakeGenericAlias(list, ('A',)), globals(), locals()
-    ) == FakeGenericAlias(list, (A,))
-    assert old_impl._eval_type_backport(
-        FakeUnionType((t.ForwardRef('A'), t.ForwardRef('B'))), globals(), locals()
-    ) == ('union', A, B)
 
 
 def test_stringified_pep585_forward_refs():

--- a/tests/test_eval_type_backport.py
+++ b/tests/test_eval_type_backport.py
@@ -3,10 +3,13 @@ from __future__ import annotations
 import collections
 import contextlib
 import importlib
+import importlib.util
+import pathlib
 import re
 import sys
 import textwrap
 import typing as t
+import types
 
 import pytest
 
@@ -20,6 +23,33 @@ eval_type_backport_impl = importlib.import_module(
 
 
 eval_type = t._eval_type  # type: ignore[attr-defined]
+
+
+def load_impl_with_version(
+    monkeypatch: pytest.MonkeyPatch,
+    version_info: tuple[int, int],
+    *,
+    generic_alias: type | None = None,
+    union_type: type | None = None,
+) -> types.ModuleType:
+    if generic_alias is not None:
+        monkeypatch.setattr(types, 'GenericAlias', generic_alias, raising=False)
+    if union_type is not None:
+        monkeypatch.setattr(types, 'UnionType', union_type, raising=False)
+    monkeypatch.setattr(sys, 'version_info', version_info)
+
+    module_file = eval_type_backport_impl.__file__
+    assert module_file is not None
+    module_path = pathlib.Path(module_file)
+    spec = importlib.util.spec_from_file_location(
+        f'eval_type_backport_test_{version_info[0]}_{version_info[1]}',
+        module_path,
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 def eval_kwargs(code: str):
@@ -426,6 +456,54 @@ def test_private_backport_evaluator_pep585_forward_refs():
         )
         is recursive_ref
     )
+
+
+def test_private_backport_evaluator_version_coverage(monkeypatch: pytest.MonkeyPatch):
+    if sys.version_info[:2] >= (3, 11):
+        pytest.skip('old-version coverage shim')
+    original_version = sys.version_info[:2]
+
+    newer_impl = load_impl_with_version(monkeypatch, (3, 11))
+    assert newer_impl.eval_type_backport(int, globals(), locals()) is int
+
+    class FakeGenericAlias:
+        def __init__(self, origin: t.Any, args: t.Any):
+            self.__origin__ = origin
+            self.__args__ = args if isinstance(args, tuple) else (args,)
+
+        def __eq__(self, other: object) -> bool:
+            return (
+                isinstance(other, FakeGenericAlias)
+                and self.__origin__ == other.__origin__
+                and self.__args__ == other.__args__
+            )
+
+    class FakeUnionType:
+        def __init__(self, args: tuple[t.Any, ...]):
+            self.__args__ = args
+
+    class OrableMeta(type):
+        def __or__(self, other: object):
+            return ('union', self, other)
+
+    class A(metaclass=OrableMeta):
+        pass
+
+    class B(metaclass=OrableMeta):
+        pass
+
+    old_impl = load_impl_with_version(
+        monkeypatch,
+        original_version,
+        generic_alias=FakeGenericAlias,
+        union_type=FakeUnionType,
+    )
+    assert old_impl._eval_type_backport(
+        FakeGenericAlias(list, ('A',)), globals(), locals()
+    ) == FakeGenericAlias(list, (A,))
+    assert old_impl._eval_type_backport(
+        FakeUnionType((t.ForwardRef('A'), t.ForwardRef('B'))), globals(), locals()
+    ) == ('union', A, B)
 
 
 def test_stringified_pep585_forward_refs():

--- a/tests/test_eval_type_backport.py
+++ b/tests/test_eval_type_backport.py
@@ -4,6 +4,7 @@ import collections
 import contextlib
 import re
 import sys
+import textwrap
 import typing as t
 
 import pytest
@@ -362,3 +363,69 @@ def test_copy_forward_ref_attrs():
         **({} if sys.version_info < (3, 9, 8) else {'is_class': True}),
     )
     eval_type_backport(ref, globalns=globals(), localns=locals())
+
+
+def test_pep585_generic_alias_forward_refs():
+    if sys.version_info[:2] < (3, 9):
+        pytest.skip('PEP 585 generic aliases were added in Python 3.9')
+
+    class C1:
+        pass
+
+    C1.__annotations__ = {'a': list['C1']}
+    assert eval_type_backport(C1.__annotations__['a'], globals(), locals()) == list[C1]
+
+    class C2:
+        pass
+
+    C2.__annotations__ = {'a': dict['C1', list[t.List[list['C2']]]]}
+    assert (
+        eval_type_backport(C2.__annotations__['a'], globals(), locals())
+        == dict[C1, list[t.List[list[C2]]]]
+    )
+
+    C2.__annotations__ = {'a': list['C2 | int']}
+    assert (
+        eval_type_backport(C2.__annotations__['a'], globals(), locals())
+        == list[t.Union[C2, int]]
+    )
+
+
+def test_stringified_pep585_forward_refs():
+    class C2:
+        pass
+
+    scope = {'List': t.List, 'C2': C2}
+    exec(
+        textwrap.dedent(
+            """
+            from __future__ import annotations
+
+            class C3:
+                a: List[list["C2"]]
+            """
+        ),
+        scope,
+    )
+    C3 = scope['C3']
+    assert C3.__annotations__['a'] == "List[list['C2']]"
+
+    result = eval_type_backport(t.ForwardRef(C3.__annotations__['a']), globals(), scope)
+    expected = t.List[list[C2]] if sys.version_info[:2] >= (3, 9) else t.List[t.List[C2]]
+    assert result == expected
+
+
+def test_recursive_pep585_forward_ref():
+    if sys.version_info[:2] < (3, 9):
+        pytest.skip('PEP 585 generic aliases were added in Python 3.9')
+
+    X = list['X']
+
+    result = eval_type_backport(X, globals(), locals())
+
+    assert t.get_origin(result) is list
+    (inner_alias,) = t.get_args(result)
+    assert t.get_origin(inner_alias) is list
+    (inner_ref,) = t.get_args(inner_alias)
+    assert isinstance(inner_ref, t.ForwardRef)
+    assert inner_ref.__forward_arg__ == 'X'

--- a/tests/test_eval_type_backport.py
+++ b/tests/test_eval_type_backport.py
@@ -376,21 +376,18 @@ def test_pep585_generic_alias_forward_refs():
     class C1:
         pass
 
-    C1.__annotations__ = {'a': list['C1']}
-    assert eval_type_backport(C1.__annotations__['a'], globals(), locals()) == list[C1]
+    assert eval_type_backport(list['C1'], globals(), locals()) == list[C1]
 
     class C2:
         pass
 
-    C2.__annotations__ = {'a': dict['C1', list[t.List[list['C2']]]]}
     assert (
-        eval_type_backport(C2.__annotations__['a'], globals(), locals())
+        eval_type_backport(dict['C1', list[t.List[list['C2']]]], globals(), locals())
         == dict[C1, list[t.List[list[C2]]]]
     )
 
-    C2.__annotations__ = {'a': list['C2 | int']}
     assert (
-        eval_type_backport(C2.__annotations__['a'], globals(), locals())
+        eval_type_backport(list['C2 | int'], globals(), locals())
         == list[t.Union[C2, int]]
     )
 

--- a/tests/test_runtime_annotations.py
+++ b/tests/test_runtime_annotations.py
@@ -1,0 +1,32 @@
+import sys
+import typing as t
+
+import pytest
+
+from eval_type_backport import install_patch
+
+
+runtime_node_class: t.Optional[t.Type[t.Any]]
+if sys.version_info[:2] >= (3, 9):
+
+    class RuntimeNode:
+        children: list['RuntimeNode']
+
+    runtime_node_class = RuntimeNode
+else:
+    runtime_node_class = None
+
+
+def test_install_patch_supports_get_type_hints_for_pep585_forward_refs():
+    if runtime_node_class is None:
+        pytest.skip('PEP 585 generic aliases were added in Python 3.9')
+    runtime_node = t.cast(t.Any, runtime_node_class)
+
+    original_evaluate = t.ForwardRef._evaluate
+    original_eval_type = t._eval_type  # type: ignore[attr-defined]
+    try:
+        install_patch()
+        assert t.get_type_hints(runtime_node) == {'children': list[runtime_node]}
+    finally:
+        t.ForwardRef._evaluate = original_evaluate
+        t._eval_type = original_eval_type  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary
- backport CPython's PEP 585 generic alias string-argument evaluation for Python < 3.11
- recursively resolve nested `ForwardRef` values left inside generic aliases
- add regression coverage for direct aliases, stringified future annotations, unions, and recursive aliases

Fixes #10.

## Tests
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 tox -e py38,py39,py310,py311`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 tox -e py312,py313,py314`
- `ruff check eval_type_backport tests`
- `ruff format --check eval_type_backport/eval_type_backport.py tests/test_eval_type_backport.py`
- `pre-commit run pyright --files eval_type_backport/eval_type_backport.py`
