### PR TITLE
Improve pre-commit checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,23 @@ on:
   workflow_dispatch:
 
 jobs:
+  pre-commit:
+    name: pre-commit
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python --version
+        pip install --upgrade pip pre-commit uv
+    - name: Run pre-commit
+      run: pre-commit run --all-files
+
   test:
     name: test ${{ matrix.os }} / ${{ matrix.python-version }}
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,13 +17,17 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.x'
+        python-version: '3.13'
     - name: Install dependencies
       run: |
+        python -m venv venv
+        . venv/bin/activate
         python --version
-        pip install --upgrade pip pre-commit uv
+        pip install --upgrade pip pre-commit uv .[tests]
     - name: Run pre-commit
-      run: pre-commit run --all-files
+      run: |
+        . venv/bin/activate
+        pre-commit run --all-files
 
   test:
     name: test ${{ matrix.os }} / ${{ matrix.python-version }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,8 +16,13 @@ repos:
     language: system
     pass_filenames: false
     types_or: [python, pyi]
-- repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.15.15
-  hooks:
-    - id: ruff
-    - id: ruff-format
+  - id: ruff
+    name: ruff
+    entry: uvx ruff@latest check --force-exclude
+    language: system
+    types_or: [python, pyi]
+  - id: ruff-format
+    name: ruff format
+    entry: uvx ruff@latest format --force-exclude
+    language: system
+    types_or: [python, pyi]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.5.0
+  rev: v6.0.0
   hooks:
   - id: check-yaml
   - id: check-toml
@@ -8,12 +8,16 @@ repos:
   - id: trailing-whitespace
   - id: check-merge-conflict
   - id: debug-statements
-- repo: https://github.com/RobertCraigie/pyright-python
-  rev: v1.1.335
+- repo: local
   hooks:
   - id: pyright
+    name: pyright
+    entry: uvx pyright@latest
+    language: system
+    pass_filenames: false
+    types_or: [python, pyi]
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.1.5
+  rev: v0.15.15
   hooks:
     - id: ruff
     - id: ruff-format

--- a/eval_type_backport/eval_type_backport.py
+++ b/eval_type_backport/eval_type_backport.py
@@ -23,15 +23,15 @@ def is_not_subscriptable_error(e: TypeError) -> bool:
     return "' object is not subscriptable" in str(e)
 
 
+def _typing_alias(value: Any) -> Any:
+    return getattr(typing, value.__name__)
+
+
 def is_backport_fixable_error(e: TypeError) -> bool:
     return is_unsupported_types_for_union_error(e) or is_not_subscriptable_error(e)
 
 
 # From https://peps.python.org/pep-0585/#implementation
-def _typing_alias(value: Any) -> Any:
-    return getattr(typing, value.__name__)
-
-
 new_generic_types = {
     tuple: typing.Tuple,
     list: typing.List,

--- a/eval_type_backport/eval_type_backport.py
+++ b/eval_type_backport/eval_type_backport.py
@@ -23,10 +23,6 @@ def is_not_subscriptable_error(e: TypeError) -> bool:
     return "' object is not subscriptable" in str(e)
 
 
-def _typing_alias(value: Any) -> Any:
-    return getattr(typing, value.__name__)
-
-
 def is_backport_fixable_error(e: TypeError) -> bool:
     return is_unsupported_types_for_union_error(e) or is_not_subscriptable_error(e)
 
@@ -45,34 +41,34 @@ new_generic_types = {
     contextlib.AbstractContextManager: typing.ContextManager,
     contextlib.AbstractAsyncContextManager: typing.AsyncContextManager,
     **{
-        k: _typing_alias(k)
-        for k in (
-            collections.OrderedDict,
-            collections.Counter,
-            collections.ChainMap,
-            collections.abc.Awaitable,
-            collections.abc.Coroutine,
-            collections.abc.AsyncIterable,
-            collections.abc.AsyncIterator,
-            collections.abc.AsyncGenerator,
-            collections.abc.Iterable,
-            collections.abc.Iterator,
-            collections.abc.Generator,
-            collections.abc.Reversible,
-            collections.abc.Container,
-            collections.abc.Collection,
-            collections.abc.Callable,
-            collections.abc.MutableSet,
-            collections.abc.Mapping,
-            collections.abc.MutableMapping,
-            collections.abc.Sequence,
-            collections.abc.MutableSequence,
-            collections.abc.MappingView,
-            collections.abc.KeysView,
-            collections.abc.ItemsView,
-            collections.abc.ValuesView,
-            re.Pattern,
-            re.Match,
+        k: getattr(typing, name)
+        for k, name in (
+            (collections.OrderedDict, 'OrderedDict'),
+            (collections.Counter, 'Counter'),
+            (collections.ChainMap, 'ChainMap'),
+            (collections.abc.Awaitable, 'Awaitable'),
+            (collections.abc.Coroutine, 'Coroutine'),
+            (collections.abc.AsyncIterable, 'AsyncIterable'),
+            (collections.abc.AsyncIterator, 'AsyncIterator'),
+            (collections.abc.AsyncGenerator, 'AsyncGenerator'),
+            (collections.abc.Iterable, 'Iterable'),
+            (collections.abc.Iterator, 'Iterator'),
+            (collections.abc.Generator, 'Generator'),
+            (collections.abc.Reversible, 'Reversible'),
+            (collections.abc.Container, 'Container'),
+            (collections.abc.Collection, 'Collection'),
+            (collections.abc.Callable, 'Callable'),
+            (collections.abc.MutableSet, 'MutableSet'),
+            (collections.abc.Mapping, 'Mapping'),
+            (collections.abc.MutableMapping, 'MutableMapping'),
+            (collections.abc.Sequence, 'Sequence'),
+            (collections.abc.MutableSequence, 'MutableSequence'),
+            (collections.abc.MappingView, 'MappingView'),
+            (collections.abc.KeysView, 'KeysView'),
+            (collections.abc.ItemsView, 'ItemsView'),
+            (collections.abc.ValuesView, 'ValuesView'),
+            (re.Pattern, 'Pattern'),
+            (re.Match, 'Match'),
         )
     },
 }

--- a/eval_type_backport/eval_type_backport.py
+++ b/eval_type_backport/eval_type_backport.py
@@ -28,6 +28,36 @@ def is_backport_fixable_error(e: TypeError) -> bool:
 
 
 # From https://peps.python.org/pep-0585/#implementation
+_generic_type_origins: tuple[Any, ...] = (
+    collections.OrderedDict,
+    collections.Counter,
+    collections.ChainMap,
+    collections.abc.Awaitable,
+    collections.abc.Coroutine,
+    collections.abc.AsyncIterable,
+    collections.abc.AsyncIterator,
+    collections.abc.AsyncGenerator,
+    collections.abc.Iterable,
+    collections.abc.Iterator,
+    collections.abc.Generator,
+    collections.abc.Reversible,
+    collections.abc.Container,
+    collections.abc.Collection,
+    collections.abc.Callable,
+    collections.abc.MutableSet,
+    collections.abc.Mapping,
+    collections.abc.MutableMapping,
+    collections.abc.Sequence,
+    collections.abc.MutableSequence,
+    collections.abc.MappingView,
+    collections.abc.KeysView,
+    collections.abc.ItemsView,
+    collections.abc.ValuesView,
+    re.Pattern,
+    re.Match,
+)
+
+
 new_generic_types = {
     tuple: typing.Tuple,
     list: typing.List,
@@ -40,37 +70,7 @@ new_generic_types = {
     collections.abc.Set: typing.AbstractSet,
     contextlib.AbstractContextManager: typing.ContextManager,
     contextlib.AbstractAsyncContextManager: typing.AsyncContextManager,
-    **{
-        k: getattr(typing, name)
-        for k, name in (
-            (collections.OrderedDict, 'OrderedDict'),
-            (collections.Counter, 'Counter'),
-            (collections.ChainMap, 'ChainMap'),
-            (collections.abc.Awaitable, 'Awaitable'),
-            (collections.abc.Coroutine, 'Coroutine'),
-            (collections.abc.AsyncIterable, 'AsyncIterable'),
-            (collections.abc.AsyncIterator, 'AsyncIterator'),
-            (collections.abc.AsyncGenerator, 'AsyncGenerator'),
-            (collections.abc.Iterable, 'Iterable'),
-            (collections.abc.Iterator, 'Iterator'),
-            (collections.abc.Generator, 'Generator'),
-            (collections.abc.Reversible, 'Reversible'),
-            (collections.abc.Container, 'Container'),
-            (collections.abc.Collection, 'Collection'),
-            (collections.abc.Callable, 'Callable'),
-            (collections.abc.MutableSet, 'MutableSet'),
-            (collections.abc.Mapping, 'Mapping'),
-            (collections.abc.MutableMapping, 'MutableMapping'),
-            (collections.abc.Sequence, 'Sequence'),
-            (collections.abc.MutableSequence, 'MutableSequence'),
-            (collections.abc.MappingView, 'MappingView'),
-            (collections.abc.KeysView, 'KeysView'),
-            (collections.abc.ItemsView, 'ItemsView'),
-            (collections.abc.ValuesView, 'ValuesView'),
-            (re.Pattern, 'Pattern'),
-            (re.Match, 'Match'),
-        )
-    },
+    **{k: getattr(typing, k.__name__) for k in _generic_type_origins},
 }
 
 

--- a/eval_type_backport/eval_type_backport.py
+++ b/eval_type_backport/eval_type_backport.py
@@ -28,6 +28,10 @@ def is_backport_fixable_error(e: TypeError) -> bool:
 
 
 # From https://peps.python.org/pep-0585/#implementation
+def _typing_alias(value: Any) -> Any:
+    return getattr(typing, value.__name__)
+
+
 new_generic_types = {
     tuple: typing.Tuple,
     list: typing.List,
@@ -41,7 +45,7 @@ new_generic_types = {
     contextlib.AbstractContextManager: typing.ContextManager,
     contextlib.AbstractAsyncContextManager: typing.AsyncContextManager,
     **{
-        k: getattr(typing, k.__name__)
+        k: _typing_alias(k)
         for k in (
             collections.OrderedDict,
             collections.Counter,
@@ -186,7 +190,7 @@ else:
         """
 
         @functools.wraps(original_evaluate)
-        def _evaluate(
+        def _evaluate(  # pyright: ignore[reportIncompatibleMethodOverride]
             self,
             globalns: dict[str, Any] | None,
             localns: dict[str, Any] | None,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ write_to = "eval_type_backport/version.py"
 write_to_template = "__version__ = '{version}'"
 
 [tool.pyright]
+include = ["eval_type_backport", "tests"]
 venvPath = "."
 venv = "venv"
 


### PR DESCRIPTION
## Summary
- replace pinned Pyright and Ruff pre-commit repos with local `uvx <tool>@latest` hooks
- scope Pyright to the package and tests so full-project runs ignore local artifacts
- fix the source typing issues surfaced by latest Pyright
- add a dedicated CI job that runs `pre-commit run --all-files`

## Tests
- `pre-commit run --all-files`
- `python -m pytest tests`
- `tox -e py38`
